### PR TITLE
Phase 2: Zod schema validation on all API inputs (#19)

### DIFF
--- a/app/api/auth/send-otp/route.ts
+++ b/app/api/auth/send-otp/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerClient } from '@supabase/ssr'
+import { SendOTPSchema } from '@/lib/schemas'
 
 export async function POST(request: NextRequest) {
-  const { email } = await request.json()
-  if (!email) return NextResponse.json({ error: 'Missing email' }, { status: 400 })
+  const body = await request.json()
+  const parsed = SendOTPSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const { email } = parsed.data
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/app/api/conversation/[id]/clarifications/route.ts
+++ b/app/api/conversation/[id]/clarifications/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { applyGraphPatch, emptyGraph, type NarrativeGraph } from '@/lib/graph'
 import { decrypt, encrypt } from '@/lib/crypto'
+import { ClarificationAnswerSchema } from '@/lib/schemas'
 
 export async function GET(
   req: NextRequest,
@@ -41,11 +42,12 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: conversationId } = await params
-  const { clarificationId, answer } = await req.json()
 
-  if (!clarificationId || !answer?.trim()) {
-    return NextResponse.json({ error: 'Missing clarificationId or answer' }, { status: 400 })
+  const parsed = ClarificationAnswerSchema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
+  const { clarificationId, answer } = parsed.data
 
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -77,7 +79,7 @@ export async function PATCH(
   const now = new Date().toISOString()
   await service
     .from('clarifications')
-    .update({ status: 'answered', answer: answer.trim(), answered_at: now })
+    .update({ status: 'answered', answer, answered_at: now })
     .eq('id', clarificationId)
 
   // Load user's narrative graph and apply patch
@@ -95,7 +97,7 @@ export async function PATCH(
     clarification.entity_type,
     clarification.entity_key,
     clarification.field,
-    answer.trim()
+    answer
   )
   const newVersion = (narrativeRow?.graph_version ?? 0) + 1
 

--- a/app/api/conversation/[id]/cleanup/route.ts
+++ b/app/api/conversation/[id]/cleanup/route.ts
@@ -2,14 +2,18 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { decrypt } from '@/lib/crypto'
 import { claudeComplete, logTokenUsage, getClaudeClient } from '@/lib/ai'
+import { CleanupSchema } from '@/lib/schemas'
 
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: conversationId } = await params
-  const body = await req.json().catch(() => ({}))
-  const force = body.force === true
+  const parsed = CleanupSchema.safeParse(await req.json().catch(() => ({})))
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const force = parsed.data.force === true
 
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()

--- a/app/api/conversation/[id]/story/route.ts
+++ b/app/api/conversation/[id]/story/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { decrypt } from '@/lib/crypto'
 import { claudeComplete, logTokenUsage, getClaudeClient } from '@/lib/ai'
+import { StoryGenerateSchema, StorySaveSchema } from '@/lib/schemas'
 
 const INTENSITY_PROMPTS = {
   light: `Lightly reshape the following personal account into a journal entry. \
@@ -30,11 +31,11 @@ export async function POST(
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await req.json()
-  const intensity: 'light' | 'medium' | 'full' = body.intensity ?? 'medium'
-  if (!INTENSITY_PROMPTS[intensity]) {
-    return NextResponse.json({ error: 'Invalid intensity' }, { status: 400 })
+  const parsed = StoryGenerateSchema.safeParse(await req.json().catch(() => ({})))
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
+  const { intensity } = parsed.data
 
   const service = createServiceClient()
 
@@ -130,8 +131,11 @@ export async function PUT(
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { content } = await req.json()
-  if (typeof content !== 'string') return NextResponse.json({ error: 'Missing content' }, { status: 400 })
+  const parsed = StorySaveSchema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const { content } = parsed.data
 
   const service = createServiceClient()
 

--- a/app/api/conversation/[id]/title/route.ts
+++ b/app/api/conversation/[id]/title/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { decrypt } from '@/lib/crypto'
 import { getAIClient } from '@/lib/ai'
+import { TitleGenerateSchema, TitleSaveSchema } from '@/lib/schemas'
 
 const STYLE_INSTRUCTIONS: Record<string, string> = {
   evocative: 'Evocative and emotional — captures the heart of the memory with feeling.',
@@ -16,8 +17,11 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: conversationId } = await params
-  const body = await req.json().catch(() => ({}))
-  const style: string = body.style ?? 'evocative'
+  const parsed = TitleGenerateSchema.safeParse(await req.json().catch(() => ({})))
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const { style } = parsed.data
 
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -52,7 +56,7 @@ export async function POST(
     .map(t => t.role === 'biographer' ? `Q: ${t.content}` : `A: ${t.content}`)
     .join('\n\n')
 
-  const styleNote = STYLE_INSTRUCTIONS[style] ?? STYLE_INSTRUCTIONS.evocative
+  const styleNote = STYLE_INSTRUCTIONS[style]
 
   const { client, model } = getAIClient()
   const completion = await client.chat.completions.create({
@@ -85,8 +89,11 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: conversationId } = await params
-  const { title } = await req.json()
-  if (!title?.trim()) return NextResponse.json({ error: 'Title required' }, { status: 400 })
+  const parsed = TitleSaveSchema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const { title } = parsed.data
 
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -96,7 +103,7 @@ export async function PATCH(
 
   await service
     .from('conversations')
-    .update({ topic: title.trim() })
+    .update({ topic: title })
     .eq('id', conversationId)
     .eq('user_id', user.id)
 

--- a/app/api/conversation/append/route.ts
+++ b/app/api/conversation/append/route.ts
@@ -2,16 +2,18 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { encrypt } from '@/lib/crypto'
 import { inngest } from '@/inngest/client'
+import { ConversationAppendSchema } from '@/lib/schemas'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { conversationId, responseText } = await request.json()
-  if (!conversationId || !responseText?.trim()) {
-    return NextResponse.json({ error: 'Missing conversationId or response' }, { status: 400 })
+  const parsed = ConversationAppendSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
+  const { conversationId, responseText } = parsed.data
 
   const service = createServiceClient()
 
@@ -27,7 +29,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Conversation not found' }, { status: 404 })
   }
 
-  const encryptedResponse = encrypt(responseText.trim(), process.env.MEMORY_ENCRYPTION_KEY!)
+  const encryptedResponse = encrypt(responseText, process.env.MEMORY_ENCRYPTION_KEY!)
 
   const { data: turn, error: turnError } = await service
     .from('turns')

--- a/app/api/conversation/chat/route.ts
+++ b/app/api/conversation/chat/route.ts
@@ -2,16 +2,18 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { encrypt } from '@/lib/crypto'
 import { inngest } from '@/inngest/client'
+import { ConversationChatSchema } from '@/lib/schemas'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { conversationId, responseText } = await request.json()
-  if (!conversationId || !responseText?.trim()) {
-    return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+  const parsed = ConversationChatSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
+  const { conversationId, responseText } = parsed.data
 
   const service = createServiceClient()
 
@@ -29,7 +31,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Save user turn (encrypted)
-  const encrypted = encrypt(responseText.trim(), process.env.MEMORY_ENCRYPTION_KEY!)
+  const encrypted = encrypt(responseText, process.env.MEMORY_ENCRYPTION_KEY!)
 
   const { data: turn, error: turnError } = await service
     .from('turns')

--- a/app/api/conversation/continue/route.ts
+++ b/app/api/conversation/continue/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
+import { ConversationContinueSchema } from '@/lib/schemas'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { conversationId } = await request.json()
-  if (!conversationId) return NextResponse.json({ error: 'Missing conversationId' }, { status: 400 })
+  const parsed = ConversationContinueSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const { conversationId } = parsed.data
 
   const service = createServiceClient()
 

--- a/app/api/conversation/settle/route.ts
+++ b/app/api/conversation/settle/route.ts
@@ -1,14 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { inngest } from '@/inngest/client'
+import { ConversationSettleSchema } from '@/lib/schemas'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { conversationId } = await request.json()
-  if (!conversationId) return NextResponse.json({ error: 'Missing conversationId' }, { status: 400 })
+  const parsed = ConversationSettleSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const { conversationId } = parsed.data
 
   const service = createServiceClient()
 

--- a/app/api/entry/biographer-start/route.ts
+++ b/app/api/entry/biographer-start/route.ts
@@ -1,16 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { claudeComplete, logTokenUsage, getClaudeClient } from '@/lib/ai'
+import { BiographerStartSchema } from '@/lib/schemas'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { topic } = await request.json()
-  if (!topic?.trim()) {
-    return NextResponse.json({ error: 'Topic required' }, { status: 400 })
+  const parsed = BiographerStartSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
+  const { topic } = parsed.data
 
   const service = createServiceClient()
 
@@ -29,7 +31,7 @@ export async function POST(request: NextRequest) {
 Write ONE warm, specific opening question that invites them to start telling their story. \
 One question only. Two sentences maximum. Do not start with "I". \
 Feel like an invitation to share something real, not a form field or interview prompt.`,
-    user: `${name ? `Person's name: ${name}\n` : ''}Topic they want to explore: ${topic.trim()}`,
+    user: `${name ? `Person's name: ${name}\n` : ''}Topic they want to explore: ${topic}`,
     maxTokens: 150,
     temperature: 0.7,
   })

--- a/app/api/entry/draft/route.ts
+++ b/app/api/entry/draft/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { encrypt } from '@/lib/crypto'
 import { inngest } from '@/inngest/client'
+import { EntryDraftCreateSchema, EntryDraftUpdateSchema } from '@/lib/schemas'
 
 // POST   — create a new draft conversation + user turn (no enrichment)
 // PATCH  — update existing draft turn content; pass publish:true to also fire enrichment
@@ -11,12 +12,15 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { responseText, topic } = await request.json()
-  if (!responseText?.trim()) return NextResponse.json({ error: 'Missing text' }, { status: 400 })
+  const parsed = EntryDraftCreateSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const { responseText, topic } = parsed.data
 
   const service = createServiceClient()
 
-  const topicLabel = topic?.trim() || responseText.trim().slice(0, 80)
+  const topicLabel = topic || responseText.slice(0, 80)
 
   const { data: conversation, error: convError } = await service
     .from('conversations')
@@ -41,7 +45,7 @@ export async function POST(request: NextRequest) {
       conversation_id: conversation.id,
       user_id: user.id,
       role: 'user',
-      content: encrypt(responseText.trim(), process.env.MEMORY_ENCRYPTION_KEY!),
+      content: encrypt(responseText, process.env.MEMORY_ENCRYPTION_KEY!),
       channel: 'web',
       processed: false,
     })
@@ -62,10 +66,11 @@ export async function PATCH(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { conversationId, responseText, publish } = await request.json()
-  if (!conversationId || !responseText?.trim()) {
-    return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+  const parsed = EntryDraftUpdateSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
+  const { conversationId, responseText, publish } = parsed.data
 
   const service = createServiceClient()
 
@@ -93,7 +98,7 @@ export async function PATCH(request: NextRequest) {
 
   await service
     .from('turns')
-    .update({ content: encrypt(responseText.trim(), process.env.MEMORY_ENCRYPTION_KEY!) })
+    .update({ content: encrypt(responseText, process.env.MEMORY_ENCRYPTION_KEY!) })
     .eq('id', turn.id)
 
   if (publish) {

--- a/app/api/entry/free/route.ts
+++ b/app/api/entry/free/route.ts
@@ -2,20 +2,22 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { encrypt } from '@/lib/crypto'
 import { inngest } from '@/inngest/client'
+import { EntryFreeSchema } from '@/lib/schemas'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { responseText, topic } = await request.json()
-  if (!responseText?.trim()) {
-    return NextResponse.json({ error: 'Missing entry text' }, { status: 400 })
+  const parsed = EntryFreeSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
+  const { responseText, topic } = parsed.data
 
   const service = createServiceClient()
 
-  const topicLabel = topic?.trim() || responseText.trim().slice(0, 80)
+  const topicLabel = topic || responseText.slice(0, 80)
 
   const { data: conversation, error: convError } = await service
     .from('conversations')
@@ -40,7 +42,7 @@ export async function POST(request: NextRequest) {
       conversation_id: conversation.id,
       user_id: user.id,
       role: 'user',
-      content: encrypt(responseText.trim(), process.env.MEMORY_ENCRYPTION_KEY!),
+      content: encrypt(responseText, process.env.MEMORY_ENCRYPTION_KEY!),
       channel: 'web',
       processed: false,
     })

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -1,16 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { inngest } from '@/inngest/client'
+import { OnboardingCompleteSchema } from '@/lib/schemas'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { displayName, onboardingProfile } = await request.json()
-  if (!displayName?.trim()) {
-    return NextResponse.json({ error: 'Missing display name' }, { status: 400 })
+  const parsed = OnboardingCompleteSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
+  const { displayName, onboardingProfile } = parsed.data
 
   const service = createServiceClient()
 
@@ -19,7 +21,7 @@ export async function POST(request: NextRequest) {
     .upsert({
       id: user.id,
       email: user.email!,
-      display_name: displayName.trim(),
+      display_name: displayName,
       onboarding_profile: onboardingProfile ?? {},
     }, { onConflict: 'id' })
 
@@ -31,7 +33,7 @@ export async function POST(request: NextRequest) {
   // Seed the narrative graph from onboarding data
   await inngest.send({
     name: 'fireside/onboarding.seed',
-    data: { userId: user.id, displayName: displayName.trim(), onboardingProfile: onboardingProfile ?? {} },
+    data: { userId: user.id, displayName, onboardingProfile: onboardingProfile ?? {} },
   })
 
   return NextResponse.json({ ok: true })

--- a/app/api/prompt/email/route.ts
+++ b/app/api/prompt/email/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { inngest } from '@/inngest/client'
+import { PromptEmailSchema } from '@/lib/schemas'
 
 // Manually triggers an email delivery for testing / admin use.
 // Creates a queued_prompt row, then fires fireside/prompt.deliver immediately.
@@ -10,8 +11,11 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { promptText, promptCategory } = await request.json()
-  if (!promptText) return NextResponse.json({ error: 'Missing promptText' }, { status: 400 })
+  const parsed = PromptEmailSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const { promptText, promptCategory } = parsed.data
 
   const service = createServiceClient()
 

--- a/app/api/prompt/submit/route.ts
+++ b/app/api/prompt/submit/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
 import { encrypt } from '@/lib/crypto'
 import { inngest } from '@/inngest/client'
+import { PromptSubmitSchema } from '@/lib/schemas'
 
 // Used for in-app / web prompt submission (e.g. onboarding first prompt).
 // Creates the conversation, biographer turn, and user turn, then triggers enrichment.
@@ -11,10 +12,11 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { promptText, responseText, promptCategory } = await request.json()
-  if (!promptText || !responseText?.trim()) {
-    return NextResponse.json({ error: 'Missing prompt or response' }, { status: 400 })
+  const parsed = PromptSubmitSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
+  const { promptText, responseText, promptCategory } = parsed.data
 
   const service = createServiceClient()
 
@@ -55,7 +57,7 @@ export async function POST(request: NextRequest) {
   }
 
   // User turn (encrypted)
-  const encryptedResponse = encrypt(responseText.trim(), process.env.MEMORY_ENCRYPTION_KEY!)
+  const encryptedResponse = encrypt(responseText, process.env.MEMORY_ENCRYPTION_KEY!)
 
   const { data: userTurn, error: userTurnError } = await service
     .from('turns')

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,23 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createServiceClient } from '@/lib/supabase/server'
+import { SettingsUpdateSchema } from '@/lib/schemas'
 
 export async function PATCH(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
-  const allowed = ['display_name', 'cadence', 'is_active'] as const
-  type AllowedKey = typeof allowed[number]
-
-  const updates: Partial<Record<AllowedKey, unknown>> = {}
-  for (const key of allowed) {
-    if (key in body) updates[key] = body[key]
+  const parsed = SettingsUpdateSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.flatten() }, { status: 400 })
   }
 
-  if (Object.keys(updates).length === 0) {
-    return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 })
-  }
+  const { display_name, cadence, is_active } = parsed.data
+  const updates: Record<string, unknown> = {}
+  if (display_name !== undefined) updates.display_name = display_name
+  if (cadence !== undefined) updates.cadence = cadence
+  if (is_active !== undefined) updates.is_active = is_active
 
   const service = createServiceClient()
   const { error } = await service

--- a/lib/schemas.test.ts
+++ b/lib/schemas.test.ts
@@ -1,0 +1,737 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SendOTPSchema,
+  OnboardingCompleteSchema,
+  SettingsUpdateSchema,
+  ConversationChatSchema,
+  ConversationAppendSchema,
+  ConversationSettleSchema,
+  ConversationContinueSchema,
+  StoryGenerateSchema,
+  StorySaveSchema,
+  CleanupSchema,
+  TitleGenerateSchema,
+  TitleSaveSchema,
+  ClarificationAnswerSchema,
+  EntryFreeSchema,
+  EntryDraftCreateSchema,
+  EntryDraftUpdateSchema,
+  BiographerStartSchema,
+  PromptSubmitSchema,
+  PromptEmailSchema,
+} from './schemas'
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000'
+const ANOTHER_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function expectFail(schema: { safeParse: (v: unknown) => { success: boolean } }, input: unknown) {
+  const result = schema.safeParse(input)
+  expect(result.success, `Expected validation to fail for: ${JSON.stringify(input)}`).toBe(false)
+}
+
+function expectPass(schema: { safeParse: (v: unknown) => { success: boolean; data?: unknown } }, input: unknown) {
+  const result = schema.safeParse(input)
+  expect(result.success, `Expected validation to pass for: ${JSON.stringify(input)}`).toBe(true)
+  return (result as { success: true; data: unknown }).data
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/auth/send-otp
+// ---------------------------------------------------------------------------
+
+describe('SendOTPSchema', () => {
+  it('accepts a valid email', () => {
+    expectPass(SendOTPSchema, { email: 'user@example.com' })
+  })
+
+  it('accepts emails with subdomains', () => {
+    expectPass(SendOTPSchema, { email: 'user@mail.example.co.uk' })
+  })
+
+  it('rejects missing email field', () => {
+    expectFail(SendOTPSchema, {})
+  })
+
+  it('rejects empty string email', () => {
+    expectFail(SendOTPSchema, { email: '' })
+  })
+
+  it('rejects null email', () => {
+    expectFail(SendOTPSchema, { email: null })
+  })
+
+  it('rejects non-email string', () => {
+    expectFail(SendOTPSchema, { email: 'not-an-email' })
+  })
+
+  it('rejects email without domain', () => {
+    expectFail(SendOTPSchema, { email: 'user@' })
+  })
+
+  it('rejects email without @', () => {
+    expectFail(SendOTPSchema, { email: 'userexample.com' })
+  })
+
+  it('rejects numeric email', () => {
+    expectFail(SendOTPSchema, { email: 12345 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/onboarding/complete
+// ---------------------------------------------------------------------------
+
+describe('OnboardingCompleteSchema', () => {
+  it('accepts valid displayName', () => {
+    expectPass(OnboardingCompleteSchema, { displayName: 'Alice' })
+  })
+
+  it('accepts displayName with onboardingProfile', () => {
+    expectPass(OnboardingCompleteSchema, {
+      displayName: 'Bob',
+      onboardingProfile: { age: 30, interests: ['reading'] },
+    })
+  })
+
+  it('strips leading/trailing whitespace from displayName', () => {
+    const result = expectPass(OnboardingCompleteSchema, { displayName: '  Alice  ' }) as { displayName: string }
+    expect(result.displayName).toBe('Alice')
+  })
+
+  it('rejects missing displayName', () => {
+    expectFail(OnboardingCompleteSchema, {})
+  })
+
+  it('rejects empty displayName', () => {
+    expectFail(OnboardingCompleteSchema, { displayName: '' })
+  })
+
+  it('rejects whitespace-only displayName', () => {
+    expectFail(OnboardingCompleteSchema, { displayName: '   ' })
+  })
+
+  it('rejects null displayName', () => {
+    expectFail(OnboardingCompleteSchema, { displayName: null })
+  })
+
+  it('rejects oversized displayName (>100 chars)', () => {
+    expectFail(OnboardingCompleteSchema, { displayName: 'A'.repeat(101) })
+  })
+
+  it('accepts exactly 100-char displayName', () => {
+    expectPass(OnboardingCompleteSchema, { displayName: 'A'.repeat(100) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PATCH /api/settings
+// ---------------------------------------------------------------------------
+
+describe('SettingsUpdateSchema', () => {
+  it('accepts display_name only', () => {
+    expectPass(SettingsUpdateSchema, { display_name: 'Alice' })
+  })
+
+  it('accepts is_active only', () => {
+    expectPass(SettingsUpdateSchema, { is_active: false })
+  })
+
+  it('accepts cadence only', () => {
+    expectPass(SettingsUpdateSchema, { cadence: 'weekly' })
+  })
+
+  it('accepts all fields together', () => {
+    expectPass(SettingsUpdateSchema, { display_name: 'Bob', cadence: 'few_per_week', is_active: true })
+  })
+
+  it('rejects empty object (no valid fields)', () => {
+    expectFail(SettingsUpdateSchema, {})
+  })
+
+  it('rejects empty display_name', () => {
+    expectFail(SettingsUpdateSchema, { display_name: '' })
+  })
+
+  it('rejects whitespace-only display_name', () => {
+    expectFail(SettingsUpdateSchema, { display_name: '   ' })
+  })
+
+  it('rejects invalid cadence value', () => {
+    expectFail(SettingsUpdateSchema, { cadence: 'biweekly' })
+  })
+
+  it('rejects cadence as number instead of string', () => {
+    expectFail(SettingsUpdateSchema, { cadence: 7 })
+  })
+
+  it('rejects is_active as string', () => {
+    expectFail(SettingsUpdateSchema, { is_active: 'yes' })
+  })
+
+  it('rejects oversized display_name (>100 chars)', () => {
+    expectFail(SettingsUpdateSchema, { display_name: 'X'.repeat(101) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/conversation/chat
+// ---------------------------------------------------------------------------
+
+describe('ConversationChatSchema', () => {
+  it('accepts valid conversationId and responseText', () => {
+    expectPass(ConversationChatSchema, { conversationId: VALID_UUID, responseText: 'Hello' })
+  })
+
+  it('trims responseText before min-length check', () => {
+    const result = expectPass(ConversationChatSchema, { conversationId: VALID_UUID, responseText: '  hi  ' }) as { responseText: string }
+    expect(result.responseText).toBe('hi')
+  })
+
+  it('rejects missing conversationId', () => {
+    expectFail(ConversationChatSchema, { responseText: 'Hello' })
+  })
+
+  it('rejects missing responseText', () => {
+    expectFail(ConversationChatSchema, { conversationId: VALID_UUID })
+  })
+
+  it('rejects empty responseText', () => {
+    expectFail(ConversationChatSchema, { conversationId: VALID_UUID, responseText: '' })
+  })
+
+  it('rejects whitespace-only responseText', () => {
+    expectFail(ConversationChatSchema, { conversationId: VALID_UUID, responseText: '   ' })
+  })
+
+  it('rejects malformed conversationId (not a UUID)', () => {
+    expectFail(ConversationChatSchema, { conversationId: 'not-a-uuid', responseText: 'Hello' })
+  })
+
+  it('rejects numeric conversationId', () => {
+    expectFail(ConversationChatSchema, { conversationId: 12345, responseText: 'Hello' })
+  })
+
+  it('rejects null conversationId', () => {
+    expectFail(ConversationChatSchema, { conversationId: null, responseText: 'Hello' })
+  })
+
+  it('rejects null responseText', () => {
+    expectFail(ConversationChatSchema, { conversationId: VALID_UUID, responseText: null })
+  })
+
+  it('rejects oversized responseText (>50000 chars)', () => {
+    expectFail(ConversationChatSchema, { conversationId: VALID_UUID, responseText: 'x'.repeat(50_001) })
+  })
+
+  it('accepts responseText at exactly 50000 chars', () => {
+    expectPass(ConversationChatSchema, { conversationId: VALID_UUID, responseText: 'x'.repeat(50_000) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/conversation/append
+// ---------------------------------------------------------------------------
+
+describe('ConversationAppendSchema', () => {
+  it('accepts valid input', () => {
+    expectPass(ConversationAppendSchema, { conversationId: VALID_UUID, responseText: 'My response' })
+  })
+
+  it('rejects missing conversationId', () => {
+    expectFail(ConversationAppendSchema, { responseText: 'text' })
+  })
+
+  it('rejects malformed UUID', () => {
+    expectFail(ConversationAppendSchema, { conversationId: 'bad-id', responseText: 'text' })
+  })
+
+  it('rejects empty responseText', () => {
+    expectFail(ConversationAppendSchema, { conversationId: VALID_UUID, responseText: '' })
+  })
+
+  it('rejects whitespace-only responseText', () => {
+    expectFail(ConversationAppendSchema, { conversationId: VALID_UUID, responseText: '\t\n ' })
+  })
+
+  it('rejects oversized responseText', () => {
+    expectFail(ConversationAppendSchema, { conversationId: VALID_UUID, responseText: 'a'.repeat(50_001) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/conversation/settle
+// ---------------------------------------------------------------------------
+
+describe('ConversationSettleSchema', () => {
+  it('accepts valid conversationId', () => {
+    expectPass(ConversationSettleSchema, { conversationId: VALID_UUID })
+  })
+
+  it('rejects missing conversationId', () => {
+    expectFail(ConversationSettleSchema, {})
+  })
+
+  it('rejects malformed UUID', () => {
+    expectFail(ConversationSettleSchema, { conversationId: '12345' })
+  })
+
+  it('rejects null conversationId', () => {
+    expectFail(ConversationSettleSchema, { conversationId: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/conversation/continue
+// ---------------------------------------------------------------------------
+
+describe('ConversationContinueSchema', () => {
+  it('accepts valid conversationId', () => {
+    expectPass(ConversationContinueSchema, { conversationId: VALID_UUID })
+  })
+
+  it('rejects missing conversationId', () => {
+    expectFail(ConversationContinueSchema, {})
+  })
+
+  it('rejects malformed UUID', () => {
+    expectFail(ConversationContinueSchema, { conversationId: 'abc' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/conversation/[id]/story
+// ---------------------------------------------------------------------------
+
+describe('StoryGenerateSchema', () => {
+  it('defaults intensity to medium when omitted', () => {
+    const result = expectPass(StoryGenerateSchema, {}) as { intensity: string }
+    expect(result.intensity).toBe('medium')
+  })
+
+  it('accepts light intensity', () => {
+    expectPass(StoryGenerateSchema, { intensity: 'light' })
+  })
+
+  it('accepts medium intensity', () => {
+    expectPass(StoryGenerateSchema, { intensity: 'medium' })
+  })
+
+  it('accepts full intensity', () => {
+    expectPass(StoryGenerateSchema, { intensity: 'full' })
+  })
+
+  it('rejects invalid intensity value', () => {
+    expectFail(StoryGenerateSchema, { intensity: 'ultra' })
+  })
+
+  it('rejects numeric intensity', () => {
+    expectFail(StoryGenerateSchema, { intensity: 1 })
+  })
+
+  it('rejects null intensity', () => {
+    expectFail(StoryGenerateSchema, { intensity: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PUT /api/conversation/[id]/story
+// ---------------------------------------------------------------------------
+
+describe('StorySaveSchema', () => {
+  it('accepts non-empty content', () => {
+    expectPass(StorySaveSchema, { content: 'My story text' })
+  })
+
+  it('accepts empty string content (saving an empty draft is valid)', () => {
+    expectPass(StorySaveSchema, { content: '' })
+  })
+
+  it('rejects missing content', () => {
+    expectFail(StorySaveSchema, {})
+  })
+
+  it('rejects null content', () => {
+    expectFail(StorySaveSchema, { content: null })
+  })
+
+  it('rejects numeric content', () => {
+    expectFail(StorySaveSchema, { content: 42 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/conversation/[id]/cleanup
+// ---------------------------------------------------------------------------
+
+describe('CleanupSchema', () => {
+  it('accepts empty body (force defaults to undefined)', () => {
+    expectPass(CleanupSchema, {})
+  })
+
+  it('accepts force: true', () => {
+    expectPass(CleanupSchema, { force: true })
+  })
+
+  it('accepts force: false', () => {
+    expectPass(CleanupSchema, { force: false })
+  })
+
+  it('rejects force as string', () => {
+    expectFail(CleanupSchema, { force: 'true' })
+  })
+
+  it('rejects force as number', () => {
+    expectFail(CleanupSchema, { force: 1 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/conversation/[id]/title
+// ---------------------------------------------------------------------------
+
+describe('TitleGenerateSchema', () => {
+  it('defaults style to evocative when omitted', () => {
+    const result = expectPass(TitleGenerateSchema, {}) as { style: string }
+    expect(result.style).toBe('evocative')
+  })
+
+  it('accepts each valid style', () => {
+    for (const style of ['evocative', 'witty', 'playful', 'poetic', 'simple']) {
+      expectPass(TitleGenerateSchema, { style })
+    }
+  })
+
+  it('rejects invalid style value', () => {
+    expectFail(TitleGenerateSchema, { style: 'dramatic' })
+  })
+
+  it('rejects numeric style', () => {
+    expectFail(TitleGenerateSchema, { style: 1 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PATCH /api/conversation/[id]/title
+// ---------------------------------------------------------------------------
+
+describe('TitleSaveSchema', () => {
+  it('accepts a valid title', () => {
+    expectPass(TitleSaveSchema, { title: 'My Memoir Entry' })
+  })
+
+  it('strips surrounding whitespace', () => {
+    const result = expectPass(TitleSaveSchema, { title: '  Summer Days  ' }) as { title: string }
+    expect(result.title).toBe('Summer Days')
+  })
+
+  it('rejects missing title', () => {
+    expectFail(TitleSaveSchema, {})
+  })
+
+  it('rejects empty title', () => {
+    expectFail(TitleSaveSchema, { title: '' })
+  })
+
+  it('rejects whitespace-only title', () => {
+    expectFail(TitleSaveSchema, { title: '   ' })
+  })
+
+  it('rejects null title', () => {
+    expectFail(TitleSaveSchema, { title: null })
+  })
+
+  it('rejects oversized title (>200 chars)', () => {
+    expectFail(TitleSaveSchema, { title: 'T'.repeat(201) })
+  })
+
+  it('accepts exactly 200-char title', () => {
+    expectPass(TitleSaveSchema, { title: 'T'.repeat(200) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PATCH /api/conversation/[id]/clarifications
+// ---------------------------------------------------------------------------
+
+describe('ClarificationAnswerSchema', () => {
+  it('accepts valid clarificationId and answer', () => {
+    expectPass(ClarificationAnswerSchema, { clarificationId: VALID_UUID, answer: 'Yes, that is correct' })
+  })
+
+  it('rejects missing clarificationId', () => {
+    expectFail(ClarificationAnswerSchema, { answer: 'Yes' })
+  })
+
+  it('rejects malformed clarificationId', () => {
+    expectFail(ClarificationAnswerSchema, { clarificationId: 'not-a-uuid', answer: 'Yes' })
+  })
+
+  it('rejects missing answer', () => {
+    expectFail(ClarificationAnswerSchema, { clarificationId: VALID_UUID })
+  })
+
+  it('rejects empty answer', () => {
+    expectFail(ClarificationAnswerSchema, { clarificationId: VALID_UUID, answer: '' })
+  })
+
+  it('rejects whitespace-only answer', () => {
+    expectFail(ClarificationAnswerSchema, { clarificationId: VALID_UUID, answer: '   ' })
+  })
+
+  it('rejects oversized answer (>10000 chars)', () => {
+    expectFail(ClarificationAnswerSchema, { clarificationId: VALID_UUID, answer: 'a'.repeat(10_001) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/entry/free
+// ---------------------------------------------------------------------------
+
+describe('EntryFreeSchema', () => {
+  it('accepts responseText only', () => {
+    expectPass(EntryFreeSchema, { responseText: 'Today I went hiking.' })
+  })
+
+  it('accepts responseText with topic', () => {
+    expectPass(EntryFreeSchema, { responseText: 'Today I went hiking.', topic: 'Outdoors' })
+  })
+
+  it('rejects missing responseText', () => {
+    expectFail(EntryFreeSchema, {})
+  })
+
+  it('rejects empty responseText', () => {
+    expectFail(EntryFreeSchema, { responseText: '' })
+  })
+
+  it('rejects whitespace-only responseText', () => {
+    expectFail(EntryFreeSchema, { responseText: '   ' })
+  })
+
+  it('rejects null responseText', () => {
+    expectFail(EntryFreeSchema, { responseText: null })
+  })
+
+  it('rejects oversized responseText (>50000 chars)', () => {
+    expectFail(EntryFreeSchema, { responseText: 'w'.repeat(50_001) })
+  })
+
+  it('rejects oversized topic (>500 chars)', () => {
+    expectFail(EntryFreeSchema, { responseText: 'valid', topic: 'T'.repeat(501) })
+  })
+
+  it('accepts topic at exactly 500 chars', () => {
+    expectPass(EntryFreeSchema, { responseText: 'valid', topic: 'T'.repeat(500) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/entry/draft
+// ---------------------------------------------------------------------------
+
+describe('EntryDraftCreateSchema', () => {
+  it('accepts responseText only', () => {
+    expectPass(EntryDraftCreateSchema, { responseText: 'Draft content here.' })
+  })
+
+  it('accepts responseText with topic', () => {
+    expectPass(EntryDraftCreateSchema, { responseText: 'Draft content.', topic: 'My topic' })
+  })
+
+  it('rejects empty responseText', () => {
+    expectFail(EntryDraftCreateSchema, { responseText: '' })
+  })
+
+  it('rejects whitespace-only responseText', () => {
+    expectFail(EntryDraftCreateSchema, { responseText: '\n\t' })
+  })
+
+  it('rejects oversized responseText', () => {
+    expectFail(EntryDraftCreateSchema, { responseText: 'd'.repeat(50_001) })
+  })
+
+  it('rejects oversized topic', () => {
+    expectFail(EntryDraftCreateSchema, { responseText: 'valid', topic: 'T'.repeat(501) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PATCH /api/entry/draft
+// ---------------------------------------------------------------------------
+
+describe('EntryDraftUpdateSchema', () => {
+  it('accepts required fields without publish', () => {
+    expectPass(EntryDraftUpdateSchema, { conversationId: VALID_UUID, responseText: 'Updated content' })
+  })
+
+  it('accepts publish: true', () => {
+    expectPass(EntryDraftUpdateSchema, {
+      conversationId: VALID_UUID,
+      responseText: 'Updated content',
+      publish: true,
+    })
+  })
+
+  it('accepts publish: false', () => {
+    expectPass(EntryDraftUpdateSchema, {
+      conversationId: VALID_UUID,
+      responseText: 'Updated content',
+      publish: false,
+    })
+  })
+
+  it('rejects missing conversationId', () => {
+    expectFail(EntryDraftUpdateSchema, { responseText: 'text' })
+  })
+
+  it('rejects malformed conversationId', () => {
+    expectFail(EntryDraftUpdateSchema, { conversationId: 'bad', responseText: 'text' })
+  })
+
+  it('rejects empty responseText', () => {
+    expectFail(EntryDraftUpdateSchema, { conversationId: VALID_UUID, responseText: '' })
+  })
+
+  it('rejects publish as string', () => {
+    expectFail(EntryDraftUpdateSchema, { conversationId: VALID_UUID, responseText: 'text', publish: 'true' })
+  })
+
+  it('rejects oversized responseText', () => {
+    expectFail(EntryDraftUpdateSchema, { conversationId: VALID_UUID, responseText: 'z'.repeat(50_001) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/entry/biographer-start
+// ---------------------------------------------------------------------------
+
+describe('BiographerStartSchema', () => {
+  it('accepts a valid topic', () => {
+    expectPass(BiographerStartSchema, { topic: 'My childhood summers' })
+  })
+
+  it('strips whitespace from topic', () => {
+    const result = expectPass(BiographerStartSchema, { topic: '  My topic  ' }) as { topic: string }
+    expect(result.topic).toBe('My topic')
+  })
+
+  it('rejects missing topic', () => {
+    expectFail(BiographerStartSchema, {})
+  })
+
+  it('rejects empty topic', () => {
+    expectFail(BiographerStartSchema, { topic: '' })
+  })
+
+  it('rejects whitespace-only topic', () => {
+    expectFail(BiographerStartSchema, { topic: '   ' })
+  })
+
+  it('rejects null topic', () => {
+    expectFail(BiographerStartSchema, { topic: null })
+  })
+
+  it('rejects oversized topic (>500 chars)', () => {
+    expectFail(BiographerStartSchema, { topic: 'T'.repeat(501) })
+  })
+
+  it('accepts exactly 500-char topic', () => {
+    expectPass(BiographerStartSchema, { topic: 'T'.repeat(500) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/prompt/submit
+// ---------------------------------------------------------------------------
+
+describe('PromptSubmitSchema', () => {
+  it('accepts valid promptText and responseText', () => {
+    expectPass(PromptSubmitSchema, { promptText: 'What is your earliest memory?', responseText: 'I remember...' })
+  })
+
+  it('accepts with optional promptCategory', () => {
+    expectPass(PromptSubmitSchema, {
+      promptText: 'A question',
+      responseText: 'An answer',
+      promptCategory: 'childhood',
+    })
+  })
+
+  it('rejects missing promptText', () => {
+    expectFail(PromptSubmitSchema, { responseText: 'An answer' })
+  })
+
+  it('rejects missing responseText', () => {
+    expectFail(PromptSubmitSchema, { promptText: 'A question' })
+  })
+
+  it('rejects empty promptText', () => {
+    expectFail(PromptSubmitSchema, { promptText: '', responseText: 'answer' })
+  })
+
+  it('rejects empty responseText', () => {
+    expectFail(PromptSubmitSchema, { promptText: 'question', responseText: '' })
+  })
+
+  it('rejects whitespace-only promptText', () => {
+    expectFail(PromptSubmitSchema, { promptText: '   ', responseText: 'answer' })
+  })
+
+  it('rejects whitespace-only responseText', () => {
+    expectFail(PromptSubmitSchema, { promptText: 'question', responseText: '\n\t' })
+  })
+
+  it('rejects null promptText', () => {
+    expectFail(PromptSubmitSchema, { promptText: null, responseText: 'answer' })
+  })
+
+  it('rejects oversized promptText (>10000 chars)', () => {
+    expectFail(PromptSubmitSchema, { promptText: 'q'.repeat(10_001), responseText: 'answer' })
+  })
+
+  it('rejects oversized responseText (>50000 chars)', () => {
+    expectFail(PromptSubmitSchema, { promptText: 'question', responseText: 'r'.repeat(50_001) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/prompt/email
+// ---------------------------------------------------------------------------
+
+describe('PromptEmailSchema', () => {
+  it('accepts valid promptText', () => {
+    expectPass(PromptEmailSchema, { promptText: 'Describe your happiest moment.' })
+  })
+
+  it('accepts with optional promptCategory', () => {
+    expectPass(PromptEmailSchema, { promptText: 'A question', promptCategory: 'memories' })
+  })
+
+  it('rejects missing promptText', () => {
+    expectFail(PromptEmailSchema, {})
+  })
+
+  it('rejects empty promptText', () => {
+    expectFail(PromptEmailSchema, { promptText: '' })
+  })
+
+  it('rejects whitespace-only promptText', () => {
+    expectFail(PromptEmailSchema, { promptText: '   ' })
+  })
+
+  it('rejects null promptText', () => {
+    expectFail(PromptEmailSchema, { promptText: null })
+  })
+
+  it('rejects oversized promptText (>10000 chars)', () => {
+    expectFail(PromptEmailSchema, { promptText: 'p'.repeat(10_001) })
+  })
+
+  it('accepts promptText at exactly 10000 chars', () => {
+    expectPass(PromptEmailSchema, { promptText: 'p'.repeat(10_000) })
+  })
+})

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,0 +1,158 @@
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+const UUIDField = z.string().uuid('Must be a valid UUID')
+const TrimmedNonEmpty = (label: string, max: number) =>
+  z.string().trim().min(1, `${label} is required`).max(max, `${label} must be ${max} characters or fewer`)
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+export const SendOTPSchema = z.object({
+  email: z.string().email('Must be a valid email address'),
+})
+export type SendOTPInput = z.infer<typeof SendOTPSchema>
+
+// ---------------------------------------------------------------------------
+// Onboarding
+// ---------------------------------------------------------------------------
+
+export const OnboardingCompleteSchema = z.object({
+  displayName: TrimmedNonEmpty('Display name', 100),
+  onboardingProfile: z.record(z.string(), z.unknown()).optional(),
+})
+export type OnboardingCompleteInput = z.infer<typeof OnboardingCompleteSchema>
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+const CADENCE_VALUES = ['daily', 'few_per_week', 'weekly'] as const
+
+export const SettingsUpdateSchema = z
+  .object({
+    display_name: z.string().trim().min(1, 'Display name must not be empty').max(100).optional(),
+    cadence: z.enum(CADENCE_VALUES, { message: 'Cadence must be daily, few_per_week, or weekly' }).optional(),
+    is_active: z.boolean().optional(),
+  })
+  .refine(
+    (data) =>
+      data.display_name !== undefined ||
+      data.cadence !== undefined ||
+      data.is_active !== undefined,
+    { message: 'At least one field must be provided' }
+  )
+export type SettingsUpdateInput = z.infer<typeof SettingsUpdateSchema>
+
+// ---------------------------------------------------------------------------
+// Conversation — action bodies
+// ---------------------------------------------------------------------------
+
+export const ConversationChatSchema = z.object({
+  conversationId: UUIDField,
+  responseText: TrimmedNonEmpty('Response text', 50_000),
+})
+export type ConversationChatInput = z.infer<typeof ConversationChatSchema>
+
+export const ConversationAppendSchema = z.object({
+  conversationId: UUIDField,
+  responseText: TrimmedNonEmpty('Response text', 50_000),
+})
+export type ConversationAppendInput = z.infer<typeof ConversationAppendSchema>
+
+export const ConversationSettleSchema = z.object({
+  conversationId: UUIDField,
+})
+export type ConversationSettleInput = z.infer<typeof ConversationSettleSchema>
+
+export const ConversationContinueSchema = z.object({
+  conversationId: UUIDField,
+})
+export type ConversationContinueInput = z.infer<typeof ConversationContinueSchema>
+
+// ---------------------------------------------------------------------------
+// Conversation — [id] sub-routes
+// ---------------------------------------------------------------------------
+
+export const StoryGenerateSchema = z.object({
+  intensity: z.enum(['light', 'medium', 'full']).optional().default('medium'),
+})
+export type StoryGenerateInput = z.infer<typeof StoryGenerateSchema>
+
+export const StorySaveSchema = z.object({
+  content: z.string({ required_error: 'Content is required' }),
+})
+export type StorySaveInput = z.infer<typeof StorySaveSchema>
+
+export const CleanupSchema = z.object({
+  force: z.boolean().optional(),
+})
+export type CleanupInput = z.infer<typeof CleanupSchema>
+
+export const TitleGenerateSchema = z.object({
+  style: z
+    .enum(['evocative', 'witty', 'playful', 'poetic', 'simple'])
+    .optional()
+    .default('evocative'),
+})
+export type TitleGenerateInput = z.infer<typeof TitleGenerateSchema>
+
+export const TitleSaveSchema = z.object({
+  title: TrimmedNonEmpty('Title', 200),
+})
+export type TitleSaveInput = z.infer<typeof TitleSaveSchema>
+
+export const ClarificationAnswerSchema = z.object({
+  clarificationId: UUIDField,
+  answer: TrimmedNonEmpty('Answer', 10_000),
+})
+export type ClarificationAnswerInput = z.infer<typeof ClarificationAnswerSchema>
+
+// ---------------------------------------------------------------------------
+// Entry
+// ---------------------------------------------------------------------------
+
+export const EntryFreeSchema = z.object({
+  responseText: TrimmedNonEmpty('Entry text', 50_000),
+  topic: z.string().trim().max(500, 'Topic must be 500 characters or fewer').optional(),
+})
+export type EntryFreeInput = z.infer<typeof EntryFreeSchema>
+
+export const EntryDraftCreateSchema = z.object({
+  responseText: TrimmedNonEmpty('Entry text', 50_000),
+  topic: z.string().trim().max(500, 'Topic must be 500 characters or fewer').optional(),
+})
+export type EntryDraftCreateInput = z.infer<typeof EntryDraftCreateSchema>
+
+export const EntryDraftUpdateSchema = z.object({
+  conversationId: UUIDField,
+  responseText: TrimmedNonEmpty('Entry text', 50_000),
+  publish: z.boolean().optional(),
+})
+export type EntryDraftUpdateInput = z.infer<typeof EntryDraftUpdateSchema>
+
+export const BiographerStartSchema = z.object({
+  topic: TrimmedNonEmpty('Topic', 500),
+})
+export type BiographerStartInput = z.infer<typeof BiographerStartSchema>
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+export const PromptSubmitSchema = z.object({
+  promptText: TrimmedNonEmpty('Prompt text', 10_000),
+  responseText: TrimmedNonEmpty('Response text', 50_000),
+  promptCategory: z.string().optional(),
+})
+export type PromptSubmitInput = z.infer<typeof PromptSubmitSchema>
+
+export const PromptEmailSchema = z.object({
+  promptText: TrimmedNonEmpty('Prompt text', 10_000),
+  promptCategory: z.string().optional(),
+})
+export type PromptEmailInput = z.infer<typeof PromptEmailSchema>


### PR DESCRIPTION
Closes #19

## Summary

- Add `lib/schemas.ts`: centralized Zod schemas for all 18 API endpoints that accept JSON body input
- Add `lib/schemas.test.ts`: 130+ edge-case tests covering empty strings, null values, oversized payloads, malformed UUIDs, missing fields, and invalid enums
- Update 16 route files to use Zod `safeParse()` instead of ad-hoc manual checks

## Test plan

- [x] Run `npm test` to verify all schema tests pass alongside existing lib tests
- [ ] Verify existing app flows still work end-to-end (onboarding, chat, entry submission)

Generated with [Claude Code](https://claude.ai/code)